### PR TITLE
chore: remove deprecated action

### DIFF
--- a/index.md
+++ b/index.md
@@ -464,14 +464,16 @@ steps:
 
 #### Rust
 
-Using an action from the [rust-lang/simpleinfra](https://github.com/rust-lang/simpleinfra) repo.
-
 ```yaml
 steps:
-  - name: Set up Rust ⚙️ 🦀
-    uses: rust-lang/simpleinfra/github-actions/simple-ci@master
-    with:
-      check_fmt: true
+  - name: Install rustfmt
+    run: rustup component add rustfmt
+  - name: Check formatting
+    run: cargo fmt --all --check
+  - name: Build
+    run: cargo build --tests --workspace
+  - name: Test
+    run: cargo test --workspace
 ```
 
 #### Python


### PR DESCRIPTION
Hi, I'm Marco from the Rust Infra team 👋

As described in https://github.com/rust-lang/simpleinfra/issues/445 we want to delete the `simple-ci` GitHub action.

This PR substitutes the action with the equivalent commands 👍

Let me know if you have any questions 🙏

